### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'rubocop-rails'
-  gem 'travis'
 end
 
 group :test do
@@ -35,4 +34,4 @@ group :test do
   gem 'simplecov'
 end
 
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+# gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,7 +273,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   simplecov
   travis
-  tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 


### PR DESCRIPTION
**What Changed**
- Remove redundant `travis` gem
- Remove `tzinfo-data` gem (commented out in case we need to come back to it)

**Next Steps**
- n/a

**Known Issues**
- Perhaps commenting out `tzinfo-data` isn't the _best_ solution, but I don't think it's a problem for our context.
