### PR TITLE
Registration Path

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,19 +1,16 @@
 class UsersController < ApplicationController
-
   def new
     @user = User.new
   end
 
   def create
-    user = user_params
-    user[:email] = user[:email].downcase
-    new_user = User.new(user)
+    new_user = User.new(user_params)
     if new_user.save
       # refac?
       session[:user_id] = new_user.id
       redirect_to dashboard_index_path
     else
-      flash[:message] = "Invalid Information Entered"
+      flash[:message] = 'Invalid Information Entered'
       redirect_to registration_path
     end
   end
@@ -21,6 +18,8 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:email, :password)
+    new_user_params = params.require(:user).permit(:email, :password, :password_confirmation)
+    new_user_params[:email].downcase!
+    new_user_params
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,7 +14,7 @@ class UsersController < ApplicationController
       redirect_to dashboard_index_path
     else
       flash[:message] = "Invalid Information Entered"
-      redirect_to new_user_path
+      redirect_to registration_path
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,8 @@ class User < ApplicationRecord
   has_many :friends, through: :friendships
   has_many :invitees
   has_many :parties
-  
-  has_secure_password
+
   validates :email, uniqueness: true, presence: true
+
+  has_secure_password
 end

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @user, local: true do |form| %>
+<%= form_with model: @user, url: registration_path, local: true do |form| %>
   <%= form.label :email, 'E-mail:' %>
   <%= form.text_field :email %>
   <%= form.label :password, 'Password:' %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,9 @@
 <%= form_with model: @user, url: registration_path, local: true do |form| %>
   <%= form.label :email, 'E-mail:' %>
-  <%= form.text_field :email %>
+  <%= form.text_field :email %><br>
   <%= form.label :password, 'Password:' %>
-  <%= form.password_field :password %>
+  <%= form.password_field :password %><br>
+  <%= form.label :password_confirmation, 'Confirm Password:' %>
+  <%= form.password_field :password_confirmation %><br>
   <%= form.submit 'Register' %>
 <% end %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -7,7 +7,7 @@
   </p>
 </section>
 
-<%= link_to 'Register', new_user_path %>
+<%= link_to 'Register', registration_path %>
 <% unless current_user %>
   <%= link_to 'Log In', login_path %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 Rails.application.routes.draw do
 
   root 'welcome#index'
-  resources :users, only: [:new, :create]
   resources :dashboard, only: [:index]
-  # resources :sessions, only: [:new, :create]
+
+  get '/registration', to: 'users#new'
+  post '/registration', to: 'users#create'
 
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'

--- a/spec/features/registration_spec.rb
+++ b/spec/features/registration_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe 'registration form' do
 
     click_on 'Register'
 
-    expect(current_path).to eq(new_user_path)
+    expect(current_path).to eq(registration_path)
   end
 
   it 'submits and creates on submit' do
-    visit new_user_path
+    visit registration_path
 
     fill_in 'user[email]', with: 'beeps@beep.org'
     fill_in 'user[password]', with: 'secretbeeps'
@@ -21,7 +21,7 @@ RSpec.describe 'registration form' do
     expect(page).to have_content("Welcome beeps@beep.org!")
   end
   it "downcases email on creation" do
-    visit new_user_path
+    visit registration_path
 
     fill_in 'user[email]', with: 'beePs@BEep.Org'
     fill_in 'user[password]', with: 'secretbeeps'
@@ -32,13 +32,13 @@ RSpec.describe 'registration form' do
     expect(page).to have_content("Welcome beeps@beep.org!")
   end
   it "doesn't redirect and displays sad flash on incomplete form" do
-    visit new_user_path
+    visit registration_path
 
     fill_in 'user[email]', with: 'beePs@BEep.Org'
 
     click_on 'Register'
 
-    expect(current_path).to eq(new_user_path)
+    expect(current_path).to eq(registration_path)
     expect(page).to have_content('Invalid Information Entered')
   end
 end

--- a/spec/features/registration_spec.rb
+++ b/spec/features/registration_spec.rb
@@ -14,27 +14,44 @@ RSpec.describe 'registration form' do
 
     fill_in 'user[email]', with: 'beeps@beep.org'
     fill_in 'user[password]', with: 'secretbeeps'
+    fill_in 'user[password_confirmation]', with: 'secretbeeps'
 
     click_on 'Register'
 
     expect(current_path).to eq(dashboard_index_path)
     expect(page).to have_content("Welcome beeps@beep.org!")
   end
+
   it "downcases email on creation" do
     visit registration_path
 
     fill_in 'user[email]', with: 'beePs@BEep.Org'
     fill_in 'user[password]', with: 'secretbeeps'
+    fill_in 'user[password_confirmation]', with: 'secretbeeps'
 
     click_on 'Register'
 
     expect(current_path).to eq(dashboard_index_path)
     expect(page).to have_content("Welcome beeps@beep.org!")
   end
+
   it "doesn't redirect and displays sad flash on incomplete form" do
     visit registration_path
 
     fill_in 'user[email]', with: 'beePs@BEep.Org'
+
+    click_on 'Register'
+
+    expect(current_path).to eq(registration_path)
+    expect(page).to have_content('Invalid Information Entered')
+  end
+
+  it "doesn't redirect and displays sad flash on password mismatch" do
+    visit registration_path
+
+    fill_in 'user[email]', with: 'beePs@BEep.Org'
+    fill_in 'user[password]', with: 'secretbeeps'
+    fill_in 'user[password_confirmation]', with: 'knownbeeps'
 
     click_on 'Register'
 

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'welcome page' do
 
     expect(page).to have_link('Register')
     click_link('Register')
-    expect(current_path).to eq(new_user_path)
+    expect(current_path).to eq(registration_path)
   end
 
   it 'displays login link' do


### PR DESCRIPTION
**What Changed**
- Closes #14 
  - Change `new_user_path` to become `registration_path`. Custom routes to handle this.
  - Add password confirmation to registration form
    - Updated tests & added sad path test for unmatching passwords.

**Next Steps**
- Begin dashboard.

**Known Issues**
- Should we have a Registration controller which handles making a new user, instead of routing '/registration' to the Users controller?
